### PR TITLE
Load ModStats server side

### DIFF
--- a/common/src/main/java/com/kryeit/Missions.java
+++ b/common/src/main/java/com/kryeit/Missions.java
@@ -67,6 +67,7 @@ public class Missions {
         ModSounds.register();
         ModTags.register();
         ModEntityTypes.register();
+        ModStats.register();
         
         useBaseTab();
         finalizeRegistrate();

--- a/common/src/main/java/com/kryeit/MissionsClient.java
+++ b/common/src/main/java/com/kryeit/MissionsClient.java
@@ -1,13 +1,11 @@
 package com.kryeit;
 
 import com.kryeit.registry.ModPonders;
-import com.kryeit.registry.ModStats;
 
 public class MissionsClient {
 
     public static void initializeClient() {
         ModPonders.register();
-        ModStats.register();
 
     }
 }


### PR DESCRIPTION
If ModStats isn't registered server-side, serverPlayer.awardStat errors and causes the server to crash as the Stat it's looking for isn't registered. This fixes that. Fixes bug introduced in 474328c